### PR TITLE
feat(docker-manifest): apply additional image tags with crane

### DIFF
--- a/src/docker-manifest.nix
+++ b/src/docker-manifest.nix
@@ -190,6 +190,8 @@ in
             "$manifest" \
             "${targetProtocol}${registryName}/${registryParams.repo}:${firstTag}"
 
+          # `crane tag` is idempotent so it is not necessary to use 
+          # `builtins.tail` to remove the first tag from `_tags`
           for tag in ${builtins.toString _tags}; do
             ${craneExe} tag \
               "${registryName}/${registryParams.repo}:${firstTag}" \

--- a/src/docker-manifest.nix
+++ b/src/docker-manifest.nix
@@ -119,6 +119,7 @@
     ++ (lib.optional (_autoTags.majorMinor && lib.flocken.isNotEmpty _version && !isPreRelease _version) (lib.versions.majorMinor _version))
     ++ (lib.optional (_autoTags.major && lib.flocken.isNotEmpty _version && !isPreRelease _version) (lib.versions.major _version))
   );
+  firstTag = builtins.head _tags;
 
   _annotations =
     lib.filterAttrs
@@ -184,15 +185,14 @@ in
             --password "${registryParams.password}"
           set -x # echo on
 
-          firstTag=${builtins.head _tags}
           ${buildahExe} manifest push --all \
             --format ${format} \
             "$manifest" \
-            "${targetProtocol}${registryName}/${registryParams.repo}:$firstTag"
+            "${targetProtocol}${registryName}/${registryParams.repo}:${firstTag}"
 
           for tag in ${builtins.toString _tags}; do
             ${craneExe} tag \
-              "${registryName}/${registryParams.repo}:$firstTag" \
+              "${registryName}/${registryParams.repo}:${firstTag}" \
               "$tag"
           done
 


### PR DESCRIPTION
Hello @mirkolenz. Many thanks for flocken!
I have been using it for several months and found it to be very helpful.

When building somewhat larger images, pushing each tag in a manner that verifies the contents of each layer can take a long time.
This PR proposes to push the first tag in `_tags` with buildah and then apply subsequent tags with [crane](https://search.nixos.org/packages?channel=unstable&show=crane), which does not separately verify the hash of each layer and is thus significantly faster in my experience.

- [x] apply additional tags to images using `crane tag` instead of `buildah manifest push` 

Two potential drawbacks to consider are 

* this requires logging in via crane in addition to buildah since crane stores credentials, for example, in `$HOME/.docker/config.json` instead of `$XDG_CONFIG_DIR/containers/auth.json`
* presumably there is some robustness associated to verifying all the layer hashes when applying new tags

I think these are reasonable tradeoffs for the improved performance, but, of course, happy to discuss further if you disagree.
I may be biased since I tend to require building relatively large images with many tags while maxing out the layer limit, which makes the performance difference noticeable.
