### PR TITLE
Prefer an explicitly-set `branch` value to an inferred github branch

### DIFF
--- a/src/docker-manifest.nix
+++ b/src/docker-manifest.nix
@@ -76,7 +76,7 @@ let
     else
       "main";
 
-  _branch = if lib.flocken.isNotEmpty _github.branch then _github.branch else branch;
+  _branch = if lib.flocken.isNotEmpty branch then branch else _github.branch;
 
   defaultRegistries = { };
 


### PR DESCRIPTION
Sometimes, github refs can be tricky (e.g. in pull_request triggered actions, they are a form like "133/merge") and are unacceptable to docker registries when auto-tagging. This change allows users to use autoTag.branch=true if they set an explicit branch name.

Fixes #84 